### PR TITLE
Support python3

### DIFF
--- a/raven_cron/runner.py
+++ b/raven_cron/runner.py
@@ -86,7 +86,7 @@ class CommandReporter(object):
                 sys.stdout.write(last_lines_stdout)
                 sys.stderr.write(last_lines_stderr)
 
-        
+
     def report_fail(self, exit_status, last_lines_stdout, last_lines_stderr, elapsed):
         if self.dsn is None:
             return
@@ -115,8 +115,8 @@ class CommandReporter(object):
         file_size = buf.tell()
         if file_size < MAX_MESSAGE_SIZE:
             buf.seek(0)
-            last_lines = buf.read()
+            last_lines = buf.read().decode('utf-8')
         else:
             buf.seek(-(MAX_MESSAGE_SIZE-3), SEEK_END)
-            last_lines = '...' + buf.read()
+            last_lines = u'...' + buf.read().decode('utf-8')
         return last_lines

--- a/tests/test_command_reporter.py
+++ b/tests/test_command_reporter.py
@@ -64,8 +64,8 @@ sys.exit(2)
     client = ClientMock()
 
     reporter.run()
-    expected_stdout = '...{}'.format('a' * (MAX_MESSAGE_SIZE - 3))
-    expected_stderr = '...{}'.format('b' * (MAX_MESSAGE_SIZE - 3))
+    expected_stdout = u'...{}'.format('a' * (MAX_MESSAGE_SIZE - 3))
+    expected_stderr = u'...{}'.format('b' * (MAX_MESSAGE_SIZE - 3))
 
     sys_mock.stdout.write.assert_called_with(expected_stdout)
     sys_mock.stderr.write.assert_called_with(expected_stderr)


### PR DESCRIPTION
This may not be the best fix, but it gets the tests to pass on python 3. The tests still pass on python 2.